### PR TITLE
update add_strategy

### DIFF
--- a/vnpy_portfoliostrategy/engine.py
+++ b/vnpy_portfoliostrategy/engine.py
@@ -366,7 +366,7 @@ class StrategyEngine(BaseEngine):
         self.strategies[strategy_name] = strategy
 
         # Add vt_symbol to strategy map.
-        for vt_symbol in vt_symbols:
+        for vt_symbol in strategy.vt_symbols:
             strategies = self.symbol_strategy_map[vt_symbol]
             strategies.append(strategy)
 


### PR DESCRIPTION
for vt_symbol in vt_symbols  --> for vt_symbol in strategy.vt_symbols
This adds flexibility to users who want to change subscribed contracts in strategy__init__() automatically, rather than  editing portfolio_strategy_setting manually. especially useful for dominant contract change.
组合策略订阅合约的默认方式是读取portfolio_strategy_setting.json里面的vt_symbols列表，此处修改后可以兼容用户在自己策略的__init__()里面自定义self.vt_symbols,比如读取csv列表，查询ricequant的主力合约表等。