### PR TITLE
[Fix] 可能引起余数不能为0的报错

### DIFF
--- a/vnpy_portfoliostrategy/utility.py
+++ b/vnpy_portfoliostrategy/utility.py
@@ -10,7 +10,7 @@ class PortfolioBarGenerator:
     def __init__(
         self,
         on_bars: Callable,
-        window: int = 0,
+        window: int = 1,
         on_window_bars: Callable = None,
         interval: Interval = Interval.MINUTE
     ) -> None:


### PR DESCRIPTION
window 如果默认为 0的话，有可能会在
if not (bar.datetime.minute + 1) % self.window:
这一行引起余数不能为0的报错