### PR TITLE
[Mod]修改收盘价更新

### DIFF
--- a/vnpy_portfoliostrategy/backtesting.py
+++ b/vnpy_portfoliostrategy/backtesting.py
@@ -251,6 +251,7 @@ class BacktestingEngine:
         start_poses: dict = {}
 
         for daily_result in self.daily_results.values():
+            daily_result.start_poses = start_poses
             daily_result.calculate_pnl(
                 pre_closes,
                 start_poses,

--- a/vnpy_portfoliostrategy/backtesting.py
+++ b/vnpy_portfoliostrategy/backtesting.py
@@ -885,7 +885,7 @@ class PortfolioDailyResult:
 
     def update_close_prices(self, close_prices: Dict[str, float]) -> None:
         """更新每日收盘价"""
-        self.close_prices = close_prices
+        self.close_prices.update(close_prices)
 
         for vt_symbol, close_price in close_prices.items():
             contract_result: Optional[ContractDailyResult] = self.contract_results.get(vt_symbol, None)


### PR DESCRIPTION
如果某合约最后一笔缺失，该合约就没有收盘价了，影响pnl计算（pre_close会强行赋值为1）