### PR TITLE
[Fix]: fix output bug

### DIFF
--- a/vnpy_portfoliostrategy/backtesting.py
+++ b/vnpy_portfoliostrategy/backtesting.py
@@ -174,7 +174,7 @@ class BacktestingEngine:
                     progress += progress_delta / total_delta
                     progress = min(progress, 1)
                     progress_bar = "#" * int(progress * 10)
-                    self.output(_("{}加载进度：{} [{:.0%}]").format(
+                    self.output(_(" {}加载进度：{} [{:.0%}]").format(
                         vt_symbol, progress_bar, progress
                     ))
 


### PR DESCRIPTION
In my case, on Linux server environment with `en_US.UTF-8` `LANG` setting, original backtesting will causes an error:

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[5], line 1
----> 1 engine.load_data()

File ~/mypyenv/lib/python3.10/site-packages/vnpy_portfoliostrategy/backtesting.py:177, in BacktestingEngine.load_data(self)
    175 progress = min(progress, 1)
    176 progress_bar = "#" * int(progress * 10)
--> 177 self.output(_("{}加载进度：{} [{:.0%}]").format(
    178     vt_symbol, progress_bar, progress
    179 ))
    181 start = end + interval_delta
    182 end += (progress_delta + interval_delta)

ValueError: Unknown format code '%' for object of type 'str'
```

This modification can solve the problem, but it's a bit of a trick. (Maybe there's a thorough solution. )